### PR TITLE
Link User-defined functions to run_udf

### DIFF
--- a/documentation/1.0/udfs.md
+++ b/documentation/1.0/udfs.md
@@ -1,5 +1,5 @@
 # User-defined functions
 
-The abbreviation **UDF** stands for **user-defined function**. With this concept, users are able to upload custom code and have it executed e.g. for every pixel of a scene, allowing custom calculations on server-side data.
+The abbreviation **UDF** stands for **user-defined function**. With the simple [run_udf() process call](https://processes.openeo.org/#run_udf), users are able to upload custom code and have it executed e.g. for every pixel of a scene, allowing custom calculations on server-side data.
 
 UDFs are currently developed and evaluated outside of the core API. More information regarding the current **draft** for UDFs can be found in a [separate repository](https://github.com/Open-EO/openeo-udf). There is additional documentation available for the [UDF Framework](https://open-eo.github.io/openeo-udf/) and the [UDF API](https://open-eo.github.io/openeo-udf/api_docs/).


### PR DESCRIPTION
run_udf() is the entry point for running UDFs. This page suggests that all UDF documentation is not found under processes, but run_udf documentation is only found there.
Now it is more intuitive to go to the UDF documentation and then start running udfs.