### PR TITLE
export as JSON process graph

### DIFF
--- a/documentation/1.0/cookbook/README.md
+++ b/documentation/1.0/cookbook/README.md
@@ -577,7 +577,7 @@ var job = await con.createJob(result, "timeseries_as_JSON_js");
 </template>
 </CodeSwitcher>
 
-### Output as JSON Process Graph
+### Output: Process as JSON
 
 In some cases we want to export the JSON representation of a process we created. If you followed one of the examples above, then your end node is called `res`. If not, replace that with whatever you called your process end node.
 
@@ -587,7 +587,7 @@ In some cases we want to export the JSON representation of a process we created.
 ```python
 process = res.to_json()
 
-# if needed, write graph to file, e.g.:
+# if needed, write JSON to file, e.g.:
 with open("./process.json", "w") as tfile:
     tfile.write(process)
 ```
@@ -596,10 +596,13 @@ with open("./process.json", "w") as tfile:
 <template v-slot:r>
 
 ```r
-graph <- as(res, "Graph")
+process <- create_user_process(res, id = "-Title-", submit = FALSE)
 
-# if needed, write graph to file, e.g.:
-cat(graphToJSON(graph),file = "./process_graph.json")
+# convert list to JSON
+process <- jsonlite::toJSON(process, force = TRUE)
+
+# if needed, write JSON to file, e.g.:
+cat(process, file = "./process.json")
 ```
 
 </template>
@@ -611,10 +614,12 @@ res.result = true
 
 process = JSON.stringify(builder.toJSON())
 
-// if needed, write graph to file, e.g.:
+// if needed, write JSON to file, e.g.:
 var fs = require('fs');
 fs.writeFileSync("./process.json", process);
 ```
+
+**Note:** The above description only works with NodeJS. To do the same in a browser, methodology must be adjusted.
 
 </template>
 </CodeSwitcher>

--- a/documentation/1.0/cookbook/README.md
+++ b/documentation/1.0/cookbook/README.md
@@ -606,7 +606,14 @@ cat(graphToJSON(graph),file = "./process_graph.json")
 <template v-slot:js>
 
 ```js
+// set last node as result = true so it is recognized as the result node
+res.result = true
 
+graph = JSON.stringify(builder.toJSON(), null, 2)
+
+// if needed, write graph to file, e.g.:
+var fs = require('fs');
+fs.writeFile ("./process_graph.json", graph, function(err) {if (err) throw err;});
 ```
 
 </template>

--- a/documentation/1.0/cookbook/README.md
+++ b/documentation/1.0/cookbook/README.md
@@ -577,6 +577,41 @@ var job = await con.createJob(result, "timeseries_as_JSON_js");
 </template>
 </CodeSwitcher>
 
+### Output as JSON Process Graph
+
+In some cases we want to export the JSON representation of a process we created. If you followed one of the examples above, then your end node is called `res`. If not, replace that with whatever you called your process end node.
+
+<CodeSwitcher>
+<template v-slot:py>
+
+```python
+graph = res.to_json()
+
+# if needed, write graph to file, e.g.:
+with open("./process_graph.json", "w") as tfile:
+    tfile.write(graph)
+```
+
+</template>
+<template v-slot:r>
+
+```r
+graph <- as(res, "Graph")
+
+# if needed, write graph to file, e.g.:
+cat(graphToJSON(graph),file = "./process_graph.json")
+```
+
+</template>
+<template v-slot:js>
+
+```js
+
+```
+
+</template>
+</CodeSwitcher>
+
 ## Chapter 2
 
 In this second part of the cookbook, things are a bit less linear. We'll explore bandmath, masking and `apply_*` functionality, only that these steps are less interconnected than in the first chapter.

--- a/documentation/1.0/cookbook/README.md
+++ b/documentation/1.0/cookbook/README.md
@@ -585,11 +585,11 @@ In some cases we want to export the JSON representation of a process we created.
 <template v-slot:py>
 
 ```python
-graph = res.to_json()
+process = res.to_json()
 
 # if needed, write graph to file, e.g.:
-with open("./process_graph.json", "w") as tfile:
-    tfile.write(graph)
+with open("./process.json", "w") as tfile:
+    tfile.write(process)
 ```
 
 </template>
@@ -609,11 +609,11 @@ cat(graphToJSON(graph),file = "./process_graph.json")
 // set last node as result = true so it is recognized as the result node
 res.result = true
 
-graph = JSON.stringify(builder.toJSON(), null, 2)
+process = JSON.stringify(builder.toJSON())
 
 // if needed, write graph to file, e.g.:
 var fs = require('fs');
-fs.writeFile ("./process_graph.json", graph, function(err) {if (err) throw err;});
+fs.writeFileSync("./process.json", process);
 ```
 
 </template>

--- a/documentation/1.0/cookbook/README.md
+++ b/documentation/1.0/cookbook/README.md
@@ -619,7 +619,7 @@ var fs = require('fs');
 fs.writeFileSync("./process.json", process);
 ```
 
-**Note:** The above description only works with NodeJS. To do the same in a browser, methodology must be adjusted.
+**Note:** The code to store a file only works with NodeJS. Browsers can't write files to disk.
 
 </template>
 </CodeSwitcher>


### PR DESCRIPTION
@m-mohr can you add the js part or point me in the right direction? `toJSON` seemed to only export the current process node.