### PR TITLE
fix r process to JSON

### DIFF
--- a/documentation/1.0/cookbook/README.md
+++ b/documentation/1.0/cookbook/README.md
@@ -607,10 +607,9 @@ with open("./process.json", "w") as tfile:
 ```r
 # create a process object and serialize
 process <- as(res, "Process")
-process_serial <- process$serialize()
 
 # convert list to JSON
-process_json <- jsonlite::toJSON(process$serialize(), auto_unbox=TRUE)
+process_json <- jsonlite::toJSON(process$serialize(), auto_unbox = TRUE, force = TRUE)
 
 # if needed, write JSON to file, e.g.:
 cat(process_json, file = "./process.json")

--- a/documentation/1.0/cookbook/README.md
+++ b/documentation/1.0/cookbook/README.md
@@ -610,7 +610,7 @@ process <- as(res, "Process")
 process_serial <- process$serialize()
 
 # convert list to JSON
-process_json <- rjson::toJSON(process_serial$process_graph)
+process_json <- jsonlite::toJSON(process$serialize(), auto_unbox=TRUE)
 
 # if needed, write JSON to file, e.g.:
 cat(process_json, file = "./process.json")

--- a/documentation/1.0/cookbook/README.md
+++ b/documentation/1.0/cookbook/README.md
@@ -605,13 +605,15 @@ with open("./process.json", "w") as tfile:
 <template v-slot:r>
 
 ```r
-process <- create_user_process(res, id = "-Title-", submit = FALSE)
+# create a process object and serialize
+process <- as(res, "Process")
+process_serial <- process$serialize()
 
 # convert list to JSON
-process <- jsonlite::toJSON(process, force = TRUE)
+process_json <- rjson::toJSON(process_serial$process_graph)
 
 # if needed, write JSON to file, e.g.:
-cat(process, file = "./process.json")
+cat(process_json, file = "./process.json")
 ```
 
 </template>


### PR DESCRIPTION
In Cookbook Section "Output: Process as JSON"
* uses `as()` instead of deprecated `create_user_process`
* uses `rjson::toJSON` instead of `jsonlite::toJSON`, because the latter is adding `[]` brackets around the `process_id` by default, which causes errors