### PR TITLE
Change the legacy_alias 'send_job' to 'create_job' in example snippets.

### DIFF
--- a/documentation/1.0/cookbook/README.md
+++ b/documentation/1.0/cookbook/README.md
@@ -439,7 +439,7 @@ Different from the creation of a PNG image, the raster format doesn't need scali
 res = cube_s2_b8_red.save_result(format = "GTiff")
 
 # send job to back-end, do not execute
-job = res.send_job(title = "temporal_mean_as_GTiff_py")
+job = res.create_job(title = "temporal_mean_as_GTiff_py")
 ```
 
 </template>
@@ -494,7 +494,7 @@ res = cube_s2_b348_red_lin.save_result(format = "PNG", options = {
       })
 
 # send job to back-end
-job = res.send_job(title = "temporal_mean_as_PNG_py")
+job = res.create_job(title = "temporal_mean_as_PNG_py")
 ```
 
 In python, options are passed as a dictionary
@@ -553,7 +553,7 @@ We can now save the timeseries in the [aggregated](#spatial-aggregation-aggregat
 res = cube_s2_b8_agg.save_result(format = "JSON")
 
 # send job to back-end
-job = res.send_job(title = "timeseries_as_JSON_py")
+job = res.create_job(title = "timeseries_as_JSON_py")
 ```
 
 </template>

--- a/documentation/1.0/python/index.md
+++ b/documentation/1.0/python/index.md
@@ -274,11 +274,11 @@ but for this introduction we'll focus on batch jobs, which is a good default cho
 ### Batch job execution
 
 The `result` datacube object we built above describes the desired input collections, processing steps and output format.
-We can now just send this description to the back-end to create a batch job with the [`send_job` method](https://open-eo.github.io/openeo-python-client/api.html#openeo.rest.datacube.DataCube.send_job) like this:
+We can now just send this description to the back-end to create a batch job with the [`create_job` method](https://open-eo.github.io/openeo-python-client/api.html#openeo.rest.datacube.DataCube.create_job) like this:
 
 ```python
 # Creating a new job at the back-end by sending the datacube information.
-job = result.send_job()
+job = result.create_job()
 ```
 
 The batch job, which is referenced by the returned `job` object, is just created at the back-end, 
@@ -367,7 +367,7 @@ RGB = RGB.save_result(format="GTIFF-THUMB")
 
 # With the last process we have finished the datacube definition and can create and start the job at the back-end.
 
-job = RGB.send_job()
+job = RGB.create_job()
 job.start_and_wait().download_results()
 ```
 


### PR DESCRIPTION
The rename in the URL also works.
The deprecation in the code was made on 14/03/2022.
@jdries 