### PR TITLE
Glossary: a process graph does not always have to be concrete

### DIFF
--- a/documentation/1.0/glossary.md
+++ b/documentation/1.0/glossary.md
@@ -18,7 +18,7 @@ A **pre-defined process** is a process provided by the *back-end*, often one of 
 
 A **user-defined process** is a process defined by the *user*. It can directly be part of another process graph or be stored as custom process on a back-end. Internally it is a *process graph* with optional additional metadata.
 
-A **process graph** chains specific process calls from the set of pre-defined and user-defined processes together. A process graph itself is a (user-defined) process again. Similarly to scripts in the context of programming, process graphs organize and automate the execution of one or more processes that could alternatively be executed individually. In a process graph, processes need to be specific, i.e. concrete values for input parameters need to be specified. These arguments can again be process graphs, scalar values, arrays or objects.
+A **process graph** chains specific process calls from the set of pre-defined and user-defined processes together. A process graph itself is a (user-defined) process again. Similarly to scripts in the context of programming, process graphs organize and automate the execution of one or more processes that could alternatively be executed individually.
 
 ## EO data (Collections)
 


### PR DESCRIPTION
[glossary on process graphs](https://openeo.org/documentation/1.0/glossary.html#processes):

>  In a process graph, processes need to be specific, i.e. concrete values for input parameters need to be specified. These arguments can again be process graphs, scalar values, arrays or objects.


I think we should drop that,  otherwise it is impossible to define a (parameterized) UDP 